### PR TITLE
Avoid insecure HTTP with maven central

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -91,7 +91,7 @@
   <property name="ivy.dir" location="ivy" />
   <loadproperties srcfile="${ivy.dir}/libraries.properties"/>
   <property name="ivy.jar" location="${ivy.dir}/ivy-${ivy.version}.jar"/>
-  <property name="ivy_repo_url" value="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar"/>
+  <property name="ivy_repo_url" value="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar"/>
   <property name="ivysettings.xml" location="${ivy.dir}/ivysettings.xml" />
   <property name="ivy.org" value="com.hadoop.compression"/>
   <property name="build.dir" location="build" />


### PR DESCRIPTION
See https://support.sonatype.com/hc/en-us/articles/360041287334
for context.

This fixes the build, which was previously failing with an error.